### PR TITLE
Add linkprefix to rubyinside and jsninja sites

### DIFF
--- a/lib/scrapesites.js
+++ b/lib/scrapesites.js
@@ -66,7 +66,7 @@ Meteor.scrapes = [
 		'locations': 'td.location',
 		'companies': 'td.company',
 		'links': '.title a',
-		'linkprefix': '',
+		'linkprefix': 'http://jobs.jsninja.com',
 		'pageindex': '',
 		'maxpage': '',
 		'icon': 'jsninja'
@@ -108,7 +108,7 @@ Meteor.scrapes = [
 		'locations': 'td.location',
 		'companies': 'td.company',
 		'links': '.title a',
-		'linkprefix': '',
+		'linkprefix': 'http://jobs.rubyinside.com',
 		'pageindex': '',
 		'maxpage': '',
 		'icon': 'rubyinside'


### PR DESCRIPTION
I added linkprefix to these two sites since there were issues with local links scraped not linking to the job site for details.  Third party links for the sites work just fine.

![link](https://cloud.githubusercontent.com/assets/344177/5277264/4bb6c996-7a7e-11e4-8532-aea6be9508d4.png)

Like the site, good work!
