### PR TITLE
Adds persistence to job site filters

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -12,3 +12,5 @@ http
 ficshelf:media-query
 mizzao:bootstrap-3
 gwendall:session-json
+u2622:persistent-session
+

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,3 +1,4 @@
+amplify@1.0.0
 application-configuration@1.0.3
 autoupdate@1.1.3
 base64@1.0.1
@@ -50,6 +51,7 @@ spacebars-compiler@1.0.3
 spacebars@1.0.3
 templating@1.0.9
 tracker@1.0.3
+u2622:persistent-session@0.2.1
 ui@1.0.4
 underscore@1.0.1
 url@1.0.2

--- a/client/HackerSurf.js
+++ b/client/HackerSurf.js
@@ -3,31 +3,39 @@
 // http://scotthasbrouck.com
 // Client Code
 
-//db call to get jobs and jobsites
+Meteor.startup(function() {
+	if (Session.get("checkedSitesCount") === undefined) {
+		Session.set("allSites", true);
+	}
+});
+
+// db call to get jobs and jobsites
 var filteredJobSites = function(setSession, returnCount, returnSiteCount, setAllChecked, setAllUnchecked) {
 	var jobsites = Scrapes.find({}, { url: 1, sitename: 1, _id: 0, sort: {sitename: 1} }).fetch();
 	var jobscount = 0;
 	var checkedJobSites = 0;
 	jobsites.forEach(function(jobsite) {
-		jobsite.checked = ((setAllChecked) ? true : ((setAllUnchecked) ? false : ((Session.get("activeSites." + jobsite.url) === undefined) ? true : Session.get("activeSites." + jobsite.url))));
-		if(setSession) {
-			Session.set("activeSites." + jobsite.url, jobsite.checked);
-		}
+		siteActive = Session.get("activeSites." + jobsite.url);
+		jobsite.checked = (setAllChecked || Session.get("allSites")) ? true : (setAllUnchecked ? !setAllUnchecked : (siteActive !== undefined ? siteActive : false));
 		if (jobsite.checked) {
 			checkedJobSites++;
 			if (returnCount) {
 				jobscount += jobsite.jobscount;
 			}
 		}
+		if (setSession) {
+			Session.setPersistent("activeSites." + jobsite.url, jobsite.checked);
+			Session.setPersistent("checkedSitesCount", checkedJobSites);
+		}
 	});
 	return (returnCount) ? jobscount : (returnSiteCount) ? checkedJobSites : jobsites;
 };
 
-//helpers
+// Helpers
 Template.body.helpers({
 	jobs: filteredJobSites,
 	allSitesSession: function() {
-		return ((Session.get("allSites") === undefined) ? true : Session.get("allSites"));
+		return (Session.get("allSites") === undefined) ? false : Session.get("allSites");
 	},
 	jobscount: function() {
 		return filteredJobSites(false, true);
@@ -43,23 +51,23 @@ Template.body.helpers({
 //events
 Template.body.events({
 	"change .all-sites-check input": function (event) {
-    	Session.set("allSites", event.target.checked);
-    	if (event.target.checked) {
-    		filteredJobSites(true, false, false, true);
-    	} else {
-			filteredJobSites(true, false, false, false, true);
-    	}
-    }
+			Session.set("allSites", event.target.checked);
+			if (event.target.checked) {
+				filteredJobSites(true, false, false, true);
+			} else {
+				filteredJobSites(true, false, false, false, true);
+			}
+		}
 });
 
 Template.jobsite.events({
 	"change input": function (event) {
-		Session.set("activeSites." + event.target.name, event.target.checked);
-		if(!event.target.checked) {
+		Session.setPersistent("activeSites." + event.target.name, event.target.checked);
+		if (!event.target.checked) {
 			Session.set("allSites", false);
 		}
-    }
+	}
 });
 
-//Subscribe
+// Subscribe
 Meteor.subscribe("scrapes");


### PR DESCRIPTION
Hey Scott, give this a try when you have a chance.

I made it persist your job site choices, but I also made it so that if you uncheck all and refresh it will revert to loading all sites.  There's no real reason to persist the selection of _no job sites_ in my opinion. 

Tried to stay true to your styles of syntax and tabbing, let me know what you think!

Cheers
